### PR TITLE
Prevent confusion of Python's and our use of "name"

### DIFF
--- a/_episodes/02-variables.md
+++ b/_episodes/02-variables.md
@@ -67,16 +67,16 @@ Ahmed is 42 years old
     *   Unlike some languages, which "guess" a default value.
 
 ~~~
-print(last_name)
+print(eye_color)
 ~~~
 {: .python}
 ~~~
 ---------------------------------------------------------------------------
 NameError                                 Traceback (most recent call last)
 <ipython-input-1-c1fbb4e96102> in <module>()
-----> 1 print(last_name)
+----> 1 print(eye_color)
 
-NameError: name 'last_name' is not defined
+NameError: name 'eye_color' is not defined
 ~~~
 {: .error}
 


### PR DESCRIPTION
Hello :-)   How do you feel about renaming the example variable `last_name` into something entirely different, so that there is no risk of confusing it with Python's use of `name...`?

I am preparing to teach this lesson; that's why I noticed this possible issue. If it was chosen intentionally to then talk about Python's use of `name...`, please let me know.