### PR TITLE
Rename variable to scientific term

### DIFF
--- a/_episodes/02-variables.md
+++ b/_episodes/02-variables.md
@@ -119,8 +119,8 @@ Age in three years: 45
     position.
 
 ~~~
-atom_name = 'helium'
-print(atom_name[0])
+element = 'helium'
+print(element[0])
 ~~~
 {: .python}
 ~~~
@@ -144,8 +144,8 @@ h
     the slice is a copy of part of the original string.
 
 ~~~
-atom_name = 'sodium'
-print(atom_name[0:3])
+element = 'sodium'
+print(element[0:3])
 ~~~
 {: .python}
 ~~~


### PR DESCRIPTION
["atom name" is rarely used](https://en.wikipedia.org/wiki/Special:Search?go=Go&search=%22atom+name%22). Since both strings denote chemical elements, please consider this renaming suggestion. Cheers :-)