### PR TITLE
Add reference to local Jekyll server

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ git clone https://github.com/LibraryCarpentry/lc-python-intro.git
 1. Run the Jekyll server locally
 
 ```
-cd <your-forked-repo-directory>
+cd <path-to>/lc-python-intro
 make serve
 ```
 1. The `Makefile` has other options as well. To see them type `make`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ locally. In order to do this, you'll want to do the following:
 1. Clone your fork of the repository:
 
 ```
-git clone https://github.com/LibraryCarpentry/lc-python-intro.git
+git clone https://github.com/<your-github-username>/lc-python-intro.git
 ```
 
 1. [Install Ruby](https://www.ruby-lang.org/en/downloads/)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ git clone https://github.com/LibraryCarpentry/lc-python-intro.git
 cd <path-to>/lc-python-intro
 make serve
 ```
+1. Browse to your local server: [http://localhost:4000/](http://localhost:4000/)
 1. The `Makefile` has other options as well. To see them type `make`
 
 ## Code of Conduct


### PR DESCRIPTION
Should have been done as part of #5, my bad.

Also fix the clone URL to *not* be the main repo