### PR TITLE
Update PyPi domain & "Import Libraries" challenge

### DIFF
--- a/_episodes/06-libraries.md
+++ b/_episodes/06-libraries.md
@@ -342,6 +342,6 @@ Capitalise This Sentence Again Please.
 > {: .solution}
 {: .challenge}
 
-[pypi]: https://pypi.python.org/pypi/
+[pypi]: https://pypi.org/
 [stdlib]: https://docs.python.org/3/library/
 [randommod]: https://docs.python.org/3/library/random.html

--- a/_episodes/06-libraries.md
+++ b/_episodes/06-libraries.md
@@ -258,9 +258,9 @@ Capitalise This Sentence Again Please.
 >
 > Library calls:
 > ~~~
-> 1. from string import digits
-> 2. import string
-> 3. import string as s
+> A) from string import digits
+> B) import string
+> C) import string as s
 > ~~~
 > {: .python}
 >
@@ -273,21 +273,10 @@ Capitalise This Sentence Again Please.
 > {: .python}
 > >
 > > ## Solution
-> > Importing `digits` from `string` provides the `digits` methods
-> > ~~~
-> > from string import digits MATCHES print(list(digits))
-> > ~~~
-> > {: .python}
-> > Importing `string` provides methods such as `ascii_uppercase`
-> > ~~~
-> > import string MATCHES print(string.ascii_uppercase)
-> > ~~~
-> > {: .python}
-> > Importing `string` with the alias `s` allows `s.digits`
-> > ~~~
-> > import string as s MATCHES print(list(s.digits))
-> > ~~~
-> > {: .python}
+> > A2) Importing `digits` from `string` provides the `digits` methods
+> > B3) Importing `string` provides methods such as `ascii_uppercase`, but
+> >     requires the `string.` syntax.
+> > C1) Importing `string` with the alias `s` allows `s.digits`
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/18-style.md
+++ b/_episodes/18-style.md
@@ -23,7 +23,7 @@ keypoints:
     etc.
     Adhering to PEP8 makes it easier for other Python developers to read and understand your code,
     and to understand what their contributions should look like.
-    The [PEP8 application and Python library](https://pypi.python.org/pypi/pep8)
+    The [PEP8 application and Python library](https://pypi.org/project/pep8/)
     can check your code for compliance with PEP8.
 
 ## Use assertions to check for internal errors.

--- a/_includes/links.md
+++ b/_includes/links.md
@@ -25,7 +25,7 @@
 [pandoc]: https://pandoc.org/
 [paper-now]: https://github.com/PeerJ/paper-now
 [python-gapminder]: https://swcarpentry.github.io/python-novice-gapminder/
-[pyyaml]: https://pypi.python.org/pypi/PyYAML
+[pyyaml]: https://pypi.org/project/PyYAML/
 [r-markdown]: https://rmarkdown.rstudio.com/
 [rstudio]: https://www.rstudio.com/
 [ruby-install-guide]: https://www.ruby-lang.org/en/downloads/


### PR DESCRIPTION
Sorry about these two changes at once. Am a bit too pressed for time.

The links aren't completely broken, because PyPI does server-side redirects after all. If you want to discuss the challenge change, we can do this after the Marburg workshop. This PR **doesn't have to be merged in time for Marburg**, though.