### PR TITLE
Repair & beautify hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The Library Carpentry module '[Introduction to programming with Python](https://
 
 Library Carpentry is a software skills training programme aimed at library and information professions. It builds on the work of [Software Carpentry](http://software-carpentry.org/) and [Data Carpentry](http://www.datacarpentry.org/).
 
-Library Carpentry is in the commons and for the commons. It is not tied to any institution of person. For more information on Library Carpentry, see our website [librarycarpentry.github.io/outline/](librarycarpentry.github.io/outline/).
+Library Carpentry is in the commons and for the commons. It is not tied to any institution of person. For more information on Library Carpentry, see our website [LibraryCarpentry.GitHub.io](https://librarycarpentry.github.io/).
 
 ## Contribution
 


### PR DESCRIPTION
Markdown links without `http` or some protocol info in front are at risk of being treated as relative, thus being appended to the URL of the resource they are displayed on.

On https://github.com/LibraryCarpentry/lc-python-intro#background for example, the `librarycarpentry.github.io/outline/` becomes `https://github.com/LibraryCarpentry/lc-python-intro/blob/gh-pages/librarycarpentry.github.io/outline`.