### PR TITLE
 Remove reference to the word "simple"

### DIFF
--- a/_episodes/02-variables.md
+++ b/_episodes/02-variables.md
@@ -193,7 +193,7 @@ print(ewr_422_yY, 'is', flabadab, 'years old')
 >
 > Draw a table showing the values of the variables in this program
 > after each statement is executed.
-> In simple terms, what do the last three lines of this program do?
+> What do the last three lines of this program do?
 >
 > ~~~
 > x = 1.0

--- a/_episodes/04-built-in.md
+++ b/_episodes/04-built-in.md
@@ -224,7 +224,7 @@ result of print is None
 
 > ## What Happens When
 >
-> 1. Explain in simple terms the order of operations in the following program:
+> 1. Explain the order of operations in the following program:
 >    when does the addition happen, when does the subtraction happen,
 >    when is each function called, etc.
 > 2. What is the final value of `word`?

--- a/_episodes/11-lists.md
+++ b/_episodes/11-lists.md
@@ -244,7 +244,7 @@ IndexError: string index out of range
 > ~~~
 > {: .output}
 > 
-> 1.  Explain in simple terms what `list('some string')` does.
+> 1.  Explain what `list('some string')` does.
 > 2.  What does `'-'.join(['x', 'y'])` generate?  
 > 
 > > ## Solution
@@ -333,7 +333,7 @@ IndexError: string index out of range
 > ## Sort and Sorted
 >
 > What do these two programs print?
-> In simple terms, explain the difference between `sorted(letters)` and `letters.sort()`.
+> Explain the difference between `sorted(letters)` and `letters.sort()`.
 >
 > ~~~
 > # Program A
@@ -369,12 +369,12 @@ IndexError: string index out of range
 > ## Copying (or Not)
 >
 > What do these two programs print?
-> In simple terms, explain the difference between `new = old` and `new = old[:]`.
+> Explain the difference between `new = old` and `new = old[:]`.
 >
 > ~~~
 > # Program A
 > old = list('gold')
-> new = old      # simple assignment
+> new = old      # Program A
 > new[0] = 'D'
 > print('new is', new, 'and old is', old)
 > ~~~

--- a/_episodes/14-writing-functions.md
+++ b/_episodes/14-writing-functions.md
@@ -174,7 +174,7 @@ result of call is: None
 > >
 > > ## Solution
 > > Each line of Python code is executed in order, regardless of whether that line calls
-> > out to a function, which may call out to other functions, or a simple
+> > out to a function, which may call out to other functions, or a
 > > variable assignment. In this case, the second line call to `print` will not execute until
 > > the result of `print_date` is complete in the first line.
 > {: .solution}

--- a/_episodes/18-style.md
+++ b/_episodes/18-style.md
@@ -28,7 +28,7 @@ keypoints:
 
 ## Use assertions to check for internal errors.
 
-Assertions are a simple, but powerful method for making sure that the context in which your code is executing is as you expect.
+Assertions are powerful method for making sure that the context in which your code is executing is as you expect.
 
 ~~~
 def calc_bulk_density(mass, volume):
@@ -38,7 +38,7 @@ def calc_bulk_density(mass, volume):
 ~~~
 {: .python}
 
-If the assertion is `False`, the Python interpreter raises an `AssertionError` runtime exception. The source code for the expression that failed will be displayed as part of the error message. To ignore assertions in your code run the interpreter with the '-O' (optimize) switch. Assertions should contain only simple checks and never change the state of the program. For example, an assertion should never contain an assignment.
+If the assertion is `False`, the Python interpreter raises an `AssertionError` runtime exception. The source code for the expression that failed will be displayed as part of the error message. To ignore assertions in your code run the interpreter with the '-O' (optimize) switch. Assertions should contain only basic checks and never change the state of the program. For example, an assertion should never contain an assignment.
 
 ## Use docstrings to provide online help.
 


### PR DESCRIPTION
Using the word "simple" in this context can demotivate the learners. The word "simple" is not necessary for the sentence and can be removed.