### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages

### DIFF
--- a/_episodes/01-getting-started.md
+++ b/_episodes/01-getting-started.md
@@ -20,7 +20,7 @@ keypoints:
 ## Use the Spyder IDE for editing and running Python.
 
 *   The [Anaconda package manager][anaconda] is an automated way to install the [Spyder IDE][spyder].
-    *   See [the setup instructions]({{ page.root }}/setup) for Anaconda installation instructions.
+    *   See [the setup instructions]({{ page.root }}/setup.html) for Anaconda installation instructions.
 *   It also installs all the extra libraries it needs to run.
 *   Once you have installed Python and the Spyder IDE requirements, open a shell and type:
     ~~~
@@ -29,7 +29,7 @@ keypoints:
     {: .python}
 
 *   This will start The Spyder IDE.
-*   This environment has several useful tools we can use, which you can see in different panels in the Spyder IDE. We will look into some of them. 
+*   This environment has several useful tools we can use, which you can see in different panels in the Spyder IDE. We will look into some of them.
 * You can change the positions and sizes of these panels to your preference, as you get to know them.
 
 ## Different ways of interacting with Python using Spyder
@@ -64,7 +64,7 @@ keypoints:
 > Spyder Editor
 >
 > This is a temporary script file.
-> """ 
+> """
 >~~~
 > Write the following line below these lines and press run (the green 'play' button or f5). A window might pop up asking you to specify the run settings, leave the settings as they are and press 'Run'.
 > What happens?
@@ -91,7 +91,7 @@ keypoints:
 >
 > To save the code, press 'file' and then 'save as'. Now give the file a name, for example 'mycode.py' and save it in a directory/folder where you know how to find it.
 > Look into your file system the way you usually do it. Is the file where you expect it to be?
-> 
+>
 > {: .python}
 {: .challenge}
 
@@ -99,4 +99,3 @@ keypoints:
 
 [anaconda]: https://docs.anaconda.com/anaconda/install/
 [spyder]: https://www.spyder-ide.org/
-

--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-root: ..
 ---
 {% include carpentries.html %}

--- a/_extras/design.md
+++ b/_extras/design.md
@@ -1,27 +1,25 @@
 ---
-layout: page
-title: "Lesson Design"
-root: ..
+title: Lesson Design
 ---
 
 ## Pacing and overall schedule
 
 * Pacing: The modularity of the lesson allows instructors to select the amount of content
-appropriate to the needs of the learners. 
+appropriate to the needs of the learners.
 * Each module has 15 minutes of stretch content which may be optionally included.
-* There is an additional 30 minutes built into the startup time to accomodate delays. 
+* There is an additional 30 minutes built into the startup time to accomodate delays.
 
 ### Possible paths through the lesson
 
 #### Slow morning OR afternoon
 * Startup + standard library
-* Startup + pandas 
+* Startup + pandas
 
-#### Average speed morning OR afternoon            
+#### Average speed morning OR afternoon
 * Startup + standard library + pandas
 * Startup + standard library + standard library stretch
 * Startup + pandas + pandas stretch
-        
+
 #### Full day option
 * Startup + standard library + standard library stretch + lunch + pandas + pandas stretch
 
@@ -40,7 +38,7 @@ appropriate to the needs of the learners.
 
 ### Standard library (2 hours 30 min)
 * 9:45: Understanding the environment and basic Python types and methods (15 min)
-    * Familiarization with the IDE 
+    * Familiarization with the IDE
     * Starting/stopping the IDE run or app
     * Print statements & evaluation
     * Strings
@@ -65,7 +63,7 @@ appropriate to the needs of the learners.
 
 ### Pandas (1 hour)
 * 11:15 Introduction to pandas and Jupyter (15 min)
-    * Importing pandas 
+    * Importing pandas
     * How pandas is often used
     * Using Jupyter notebooks
     * Jupyter gotchas and good practices

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,7 +1,5 @@
 ---
-layout: page
-title: "Discussion"
-root: ..
+title: Discussion
 ---
 
 There are many ways to discuss Library Carpentry lessons:
@@ -11,4 +9,3 @@ There are many ways to discuss Library Carpentry lessons:
 - Stay in touch with our [Topicbox Group](https://carpentries.topicbox.com/groups/discuss-library-carpentry).
 - Follow updates on [Twitter](https://twitter.com/LibCarpentry).
 - Make a suggestion or correct an error by [raising an Issue](https://github.com/LibraryCarpentry/lc-open-refine/issues).
-

--- a/_extras/exercises.md
+++ b/_extras/exercises.md
@@ -1,6 +1,4 @@
 ---
-layout: page
-title: "Further Exercises"
-root: ..
+title: Further Exercises
 ---
 FIXME: exercises that don't fit into the regular schedule.

--- a/_extras/figures.md
+++ b/_extras/figures.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: Figures
-root: ..
 ---
 {% include all_figures.html %}

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,5 @@
 ---
-layout: page
-title: "Instructors' Guide"
-root: ..
+title: Instructors' Guide
 ---
 
 ## General Notes

--- a/index.md
+++ b/index.md
@@ -17,7 +17,7 @@ Please note that this lesson uses Python 3 rather than Python 2.
 > ## Under Design
 >
 > **This lesson is currently in its early design stage;
-> please check [the design notes]({{ page.root }}/design/)
+> please check [the design notes]({{ page.root }}/design/index.html)
 > to see what we have so far.
 > Contributions are very welcome:
 > we would be particularly grateful for exercises
@@ -32,6 +32,6 @@ Please note that this lesson uses Python 3 rather than Python 2.
 >
 > 2. Learners must install [Anaconda](https://www.anaconda.com/download/) before the class starts.
 >
->    Please see [the setup instructions]({{ page.root }}/setup)
+>    Please see [the setup instructions]({{ page.root }}/setup.html)
 >    for details.
 {: .prereq}

--- a/index.md
+++ b/index.md
@@ -1,6 +1,7 @@
 ---
 layout: lesson
 root: .
+permalink: index.html
 ---
 
 This lesson is an introduction to programming in Python

--- a/reference.md
+++ b/reference.md
@@ -1,5 +1,3 @@
 ---
 layout: reference
-root: .
 ---
-

--- a/setup.md
+++ b/setup.md
@@ -1,19 +1,17 @@
 ---
-layout: page
-title: "Setup"
-root: .
+title: Setup
 ---
 
 ## Installing Python Using Anaconda
 
-[Python][python] is great for general-purpose programming and is a popular language 
-for scientific computing as well. Installing all of the packages required for this 
+[Python][python] is great for general-purpose programming and is a popular language
+for scientific computing as well. Installing all of the packages required for this
 lessons individually can be a bit difficult, however, so we recommend the all-in-one
 installer [Anaconda][anaconda].
 
 Regardless of how you choose to install it, please make sure you install Python
-version 3.x (e.g., Python 3.6 version). Also, please set up your Python environment at 
-least a day in advance of the workshop. If you encounter problems with the 
+version 3.x (e.g., Python 3.6 version). Also, please set up your Python environment at
+least a day in advance of the workshop. If you encounter problems with the
 installation procedure, ask your workshop organizers via e-mail for assistance so
 you are ready to go as soon as the workshop begins.
 
@@ -25,7 +23,7 @@ you are ready to go as soon as the workshop begins.
 2. Download the Python 3 installer for Windows.
 
 3. Double-click the executable and install Python 3 using _MOST_ of the
-   default settings. The only exception is to check the 
+   default settings. The only exception is to check the
    **Make Anaconda the default Python** option.
 
 ### macOS - [Video tutorial][video-mac]
@@ -39,7 +37,7 @@ you are ready to go as soon as the workshop begins.
 
 ### Linux
 
-Note that the following installation steps require you to work from the shell. 
+Note that the following installation steps require you to work from the shell.
 If you run into any difficulties, please request help before the workshop begins.
 
 1.  Open [anaconda.com/download][anaconda-dl] with your web browser.
@@ -64,15 +62,15 @@ If you run into any difficulties, please request help before the workshop begins
     d.  Press enter.
 
     e.  Follow the text-only prompts.  When the license agreement appears (a colon
-        will be present at the bottom of the screen) hold the down arrow until the 
-        bottom of the text. Type `yes` and press enter to approve the license. Press 
-        enter again to approve the default location for the files. Type `yes` and 
-        press enter to prepend Anaconda to your `PATH` (this makes the Anaconda 
+        will be present at the bottom of the screen) hold the down arrow until the
+        bottom of the text. Type `yes` and press enter to approve the license. Press
+        enter again to approve the default location for the files. Type `yes` and
+        press enter to prepend Anaconda to your `PATH` (this makes the Anaconda
         distribution the default Python).
 
 ## Starting Python
 
-We will teach Python using [Spyder][spyder]. If you installed Python using Anaconda, Spyder should already be on your system. If 
+We will teach Python using [Spyder][spyder]. If you installed Python using Anaconda, Spyder should already be on your system. If
 you did not use Anaconda, use the Python package manager pip
 (see the [Spyder website][spyder-install] for details.)
 
@@ -83,7 +81,7 @@ $ spyder
 ~~~
 {: .bash}
 
-To start the Python interpreter without Spyder, open a terminal 
+To start the Python interpreter without Spyder, open a terminal
 or Git Bash and type the command:
 
 ~~~


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Library Carpentry Lessons page](https://librarycarpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and found no internal links that need to be adjusted as part of this PR. If and when this is merged, I'll also make sure the link on https://librarycarpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.