### PR TITLE
Correct typo

### DIFF
--- a/_episodes/11-lists.md
+++ b/_episodes/11-lists.md
@@ -277,7 +277,7 @@ IndexError: string index out of range
 > > ~~~
 > > {: .output}
 > > 1.  A negative index begins at the final element. 
-> > 2.  `-(N - 1)` corresponds to the first index, which is the [0] index. 
+> > 2.  `-N` corresponds to the first index, which is the [0] index. 
 > > 3.  It removes the final element of the list. 
 > > 4.  You could do the following: `print(values[0:-1])`
 > {: .solution}


### PR DESCRIPTION
`-(N-1)` is not correct. Given a string, `s = 'cow'`, which has 3 elements:

`len(s)` => 3
`s[-1]` => 'w'
`s[-3]` => 'c' - the first element
`s[-(3-1)]` => 'o', which is not the first element (but the lesson says it is)
