### PR TITLE
Correct "Slice bounds"

### DIFF
--- a/_episodes/11-lists.md
+++ b/_episodes/11-lists.md
@@ -322,7 +322,7 @@ IndexError: string index out of range
 > > 
 > > ~~~
 > > lithium 
-> > m        
+> > ''
 > > ~~~
 > > {: .output}
 > > There is no 20th index, so the entire string is captured.  


### PR DESCRIPTION
_end_ has to be larger than _start_ - if it's smaller and a valid index, then an empty string will be returned, not the final element of the string