### PR TITLE
Adjust life cycle configuration

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -21,7 +21,7 @@ keywords: 'software, data, lesson, The Carpentries'
 
 # Life cycle stage of the lesson
 # possible values: pre-alpha, alpha, beta, stable
-life_cycle: 'stable'
+life_cycle: 'alpha'
 
 # License of the lesson materials (recommended CC-BY 4.0)
 license: 'CC-BY 4.0'


### PR DESCRIPTION
This adjusts the life cycle stage to flag up the development state of the lesson to page visitors. It will make the 'Alpha' banner appear at the top of the lesson pages.