### PR TITLE
Use append instead of re-assigning full list

### DIFF
--- a/episodes/for-loops.md
+++ b/episodes/for-loops.md
@@ -91,12 +91,15 @@ We can call the loop variable anything we like, there must be a colon at the end
 Loops are more robust ways to deal with containers like lists. Even if the values of the `odds` list changes, the loop will still work.
 
 ```python
-odds = [1, 3, 5, 7, 9, 11]
+odds.append(9)
+odds.append(11)
+print(odds)
 for num in odds:
     print(num)
 ```
 
 ```output
+[1, 3, 5, 7, 9, 11]
 1
 3
 5


### PR DESCRIPTION
In order to reinforce the introduction of append in the earlier lists episode, it might be smart to use it here and take advantage of the mutability of lists, rather than just re-creating the whole list.

The `print(odds)` line is optional and could be removed. It was added to reinforce visually the contents of the list after the append functions.
