### PR TITLE
Remove h1 in tidy.md

### DIFF
--- a/episodes/tidy.md
+++ b/episodes/tidy.md
@@ -16,7 +16,7 @@ exercises: 10
 ::::::::::::::::::::::::::::::::::::::::::::::::::
 
 
-# Tidy Data in Pandas 
+## Tidy Data in Pandas 
 
 Let's import the pickle file that contains all of our Chicago public library circulation data in a single DataFrame. We can use the Pandas `.read_pickle()` method to do so.
 


### PR DESCRIPTION
Replace the h1 (`#`) in line 19 with an h2 (`##`). It appears that having an h1 prevents the automated display of h2 titles in the navigation pane at the left side of the lesson and this change should resolve the issue.

Correct behavior:
<img width="523" alt="Screenshot 2024-06-27 at 09 19 24" src="https://github.com/LibraryCarpentry/lc-python-intro/assets/6070899/755bb9df-8073-47aa-a240-e0ae0be01c78">

Current behavior:
<img width="363" alt="Screenshot 2024-06-27 at 09 20 32" src="https://github.com/LibraryCarpentry/lc-python-intro/assets/6070899/300dd2d4-1037-4970-bf1a-bed9612d2a84">
