### PR TITLE
add tabbed install instructions

### DIFF
--- a/learners/setup.md
+++ b/learners/setup.md
@@ -9,35 +9,36 @@ Regardless of how you choose to install it, please make sure you install Python 
 
 We will teach Python using JupyterLab, a programming environment that runs in a web browser (JupyterLab will be installed by Anaconda). For this to work you will need a reasonably up-to-date browser. The current versions of the Chrome, Safari and Firefox browsers are all supported (some older browsers, including Internet Explorer version 9 and below, are not).
 
-### Windows - [Video tutorial][video-windows]
-1. Open [anaconda.com/download][anaconda-dl]
-  with your web browser.
+::::::::::::::::: tab
 
+### Windows 
+
+[Watch a video tutorial for Windows][video-windows].
+
+1. Open [anaconda.com/download][anaconda-dl] with your web browser.
 2.  Download the Anaconda for Windows installer with Python 3. (If you are not sure which version to choose, you probably want the 64-bit Graphical Installer *Anaconda3-...-Windows-x86_64.exe*)
-
 3. Install Python 3 by running the Anaconda Installer, using all of the defaults for installation except make sure to check *Add Anaconda to my PATH environment variable*.
 
-### macOS - [Video tutorial][video-mac]
-1. Open [anaconda.com/download][anaconda-dl]
-  with your web browser.
+### Mac
+
+[Watch a video tutorial for Mac][video-mac].
+
+1. Open [anaconda.com/download][anaconda-dl] with your web browser.
 2. Download the Anaconda Installer with Python 3 for macOS (you can either use the Graphical or the Command Line Installer).
 3. Install Python 3 by running the Anaconda Installer using all of the defaults for installation.
 
 ### Linux
-Note that the following installation steps require you to work from the shell.
-If you aren't comfortable doing the installation yourself stop here and request help from the workshop organizers.
+
+Note that the following installation steps require you to work from the shell. If you aren't comfortable doing the installation yourself stop here and request help from the workshop organizers.
 
 1. Open [anaconda.com/download][anaconda-dl] with your web browser.
-
 2. Download the Anaconda Installer with Python 3 for Linux.
-
 3. Open a terminal window and navigate to the directory where the executable is downloaded (e.g., `cd ~/Downloads`).
-
 4. Type `bash Anaconda3` and press <kbd>Tab</kbd> to auto-complete the full file name. The name of file you just downloaded should appear.
-
 5. Press <kbd>Enter</kbd> (or <kbd>Return</kbd> depending on your keyboard). You will follow the text-only prompts. To move through the text, press <kbd>Spacebar</kbd>. Type `yes` and press <kbd>Enter</kbd> to approve the license. Press <kbd>Enter</kbd> (or <kbd>Return</kbd>) to approve the default location for the files. Type `yes` and press <kbd>Enter</kbd> (or <kbd>Return</kbd>) to prepend Anaconda to your PATH (this makes the Anaconda distribution the default Python).
-
 6. Close the terminal window.
+
+:::::::::::::::::::::::::
 
 ## JupyterLab
 We will teach Python using JupyterLab, a part of a family of [Jupyter][jupyter] tools that includes Jupyter Notebook and JupyterLab, both of which provide interactive web environments where you can write and run Python code. If you installed Anaconda, JupyterLab is installed on your system. If you did not install Anaconda, you can [install JupyterLab][jupyter-install] on its own using conda, pip, or other popular package managers.


### PR DESCRIPTION
Closes #130.

Converts the setup instructions to use[ tabbed callouts from the Workbench](https://carpentries.github.io/sandpaper-docs/component-guide.html#tabbed-callouts). 
