### PR TITLE
adding citation cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,46 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: ' Python Intro for Libraries '
+message: >-
+  Please cite this lesson using the information in this
+  file   when you refer to it in publications, and/or if
+  you   re-use, adapt, or expand on the content in your
+  own   training material.
+type: dataset
+authors:
+  - given-names: Cody
+    family-names: Hennesy
+    orcid: 'https://orcid.org/0000-0002-9410-9810'
+  - given-names: Tim
+    family-names: Dennis
+    email: tdennis@library.ucla.edu
+    orcid: 'https://orcid.org/0000-0001-6632-3812'
+  - given-names: Scott
+    family-names: Peterson
+    orcid: 'https://orcid.org/0000-0002-1920-616X'
+  - family-names: Palmquist
+    given-names: David
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.12582386
+repository-code: 'https://github.com/LibraryCarpentry/lc-python-intro'
+url: 'https://librarycarpentry.org/lc-python-intro/'
+abstract: >-
+  This lesson is an introduction to programming in Python
+  for library and information workers with little or no
+  previous programming experience. It uses examples that are
+  relevant to a range of library use cases, and is designed
+  as a prerequisite for other Python lessons that will be
+  developed in the future (e.g., web scraping, APIs). The
+  lesson uses the JupyterLab computing environment and
+  Python 3.
+keywords:
+  - Carpentries
+  - Python
+  - Library Carpentry
+  - Jupyter Notebooks
+  - Data Science
+  - Libraries
+license: CC-BY-4.0


### PR DESCRIPTION
Adding `CITATION.cff`, machine readable citation, see: https://carpentries.org/blog/2024/07/lesson-cffs/. I only added authors with content commits from last 12 month, so we could need to go further back.

We should also adjust what we add to the README and other places.  See https://github.com/carpentries/lesson-development-training for how this integrates with GH. 