### PR TITLE
Clarify overdue fine function

### DIFF
--- a/episodes/writing-functions.md
+++ b/episodes/writing-functions.md
@@ -86,9 +86,9 @@ In the date example above, we printed the results of the function code to output
 ```python
 def calc_fine(days_overdue):
     if days_overdue <= 10:
-        fine =  days_overdue * 0.25
+        fine = days_overdue * 0.25
     else:
-        fine = (days_overdue * 0.25) + (days_overdue * .50)
+        fine = days_overdue * 0.75
     return fine
     
 fine = calc_fine(12)


### PR DESCRIPTION
The `else` statement used a redundant calculation that is the same as multiplying the days by `0.75`.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
The `else` statement used a redundant calculation that is the same as multiplying the days by `0.75`. I found this confusing when going through the tutorial, as I was searching for some reason that the variable was multiplied twice, thinking I was missing something.

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
