### PR TITLE
Reference correct DataFrame in `to_pickle`

### DIFF
--- a/episodes/tidy.md
+++ b/episodes/tidy.md
@@ -334,7 +334,7 @@ If we look at the data again, we will see our index will be set to date.
 Let's save `df_long` to use in the next episode. 
 
 ```python
-df.to_pickle('data/df_long.pkl')
+df_long.to_pickle('data/df_long.pkl')
 ```
 :::::::::::::::::::::::::::::::::::::::  challenge
 


### PR DESCRIPTION
The DataFrame without the changes made to it was passed `to_pickle`, causing the user to save the wrong data in the file.

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
The DataFrame without the changes made to it was passed `to_pickle`, causing the user to save the wrong data in the file. When I did this and then read the pickle in the next episode, I had loaded the wrong data.

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
