### PR TITLE
Add ipywidgets install for plotly

### DIFF
--- a/episodes/data-visualisation.md
+++ b/episodes/data-visualisation.md
@@ -146,6 +146,8 @@ plotting package in Python called Plotly. First let’s install and then use the
 ```python
 # uncomment below to install plotly if the import fails. 
 # !pip install plotly
+# you may also need to install ipywidgets.
+# !pip install ipywidgets
 import plotly.express as px
 ```
 

--- a/episodes/data-visualisation.md
+++ b/episodes/data-visualisation.md
@@ -146,8 +146,10 @@ plotting package in Python called Plotly. First let’s install and then use the
 ```python
 # uncomment below to install plotly if the import fails. 
 # !pip install plotly
-# you may also need to install ipywidgets.
+
+# if you didn't install Jupyter via Anaconda, you may also need to install ipywidgets.
 # !pip install ipywidgets
+
 import plotly.express as px
 ```
 


### PR DESCRIPTION
I am using just an install of JupyterLab, not through Anaconda, and I needed to also install `ipywidgets` for Plotly to work. This is mentioned in their documentation: https://plotly.com/python/getting-started/#jupyterlab-support

_If this pull request addresses an open issue on the repository, please add 'Closes #NN' below, where NN is the issue number._


_Please briefly summarise the changes made in the pull request, and the reason(s) for making these changes._
I am using just an install of JupyterLab, not through Anaconda, and I needed to also install `ipywidgets` for Plotly to work. This is mentioned in [their documentation](https://plotly.com/python/getting-started/#jupyterlab-support). When I initially ran the Plotly plots, they were just blank boxes.

_If any relevant discussions have taken place elsewhere, please provide links to these._


<details>

For more guidance on how to contribute changes to a Carpentries project, please review [the Contributing Guide](CONTRIBUTING.md) and [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html).

Please keep in mind that lesson Maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum. If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact The Carpentries Team at team@carpentries.org.

</details>
